### PR TITLE
add test for remote function call

### DIFF
--- a/test/tarantool_test.exs
+++ b/test/tarantool_test.exs
@@ -75,4 +75,9 @@ defmodule TarantoolTest do
   test "should call function", %{t: t} do
     assert {:ok, [["ok", "test param"]] } = Tarantool.Api.call(t, %{function_name: "test_func_1", tuple: ["test param"]})
   end
+
+  test "should call function with long data", %{t: t} do
+    assert {:ok, _} = Tarantool.Api.call(t, %{function_name: "test_func_2", tuple: ["00000000000000000"]})
+    assert {:ok, _} = Tarantool.Api.call(t, %{function_name: "test_func_2", tuple: ["00000000000000000000000000000000000"]})
+  end
 end

--- a/test/tarantool_test.exs
+++ b/test/tarantool_test.exs
@@ -72,4 +72,7 @@ defmodule TarantoolTest do
       index_id: nil, iterator: nil, offset: 0})
   end
 
+  test "should call function", %{t: t} do
+    assert {:ok, [["ok", "test param"]] } = Tarantool.Api.call(t, %{function_name: "test_func_1", tuple: ["test param"]})
+  end
 end

--- a/test/test.lua
+++ b/test/test.lua
@@ -1,6 +1,10 @@
 box.cfg({listen=3303})
 box.schema.user.create('test', {password='t3st', if_not_exists=true})
 
+function test_func_1(p1)
+  return {'ok', p1}
+end
+
 if not box.space.test then
     local s1 = box.schema.space.create('test', {id = 513, if_not_exists = true})
     local ip = s1:create_index('primary', {type = 'hash', parts = {1, 'NUM'}, if_not_exists = true})

--- a/test/test.lua
+++ b/test/test.lua
@@ -5,6 +5,16 @@ function test_func_1(p1)
   return {'ok', p1}
 end
 
+function test_func_2(p1)
+  result = {
+    params = {
+      id = p1
+    }
+  }
+
+  return result
+end
+
 if not box.space.test then
     local s1 = box.schema.space.create('test', {id = 513, if_not_exists = true})
     local ip = s1:create_index('primary', {type = 'hash', parts = {1, 'NUM'}, if_not_exists = true})


### PR DESCRIPTION
Here is a test for tarantool remote function call

In second commit bad case when remote call failed if string length is pretty long. Same code but with shorter string work well so I think length is a matter.

Error is:

```
00:01:41.240 [error] GenServer #PID<0.157.0> terminating
** (MatchError) no match of right hand side value: {:error, :incomplete}
    (tarantool) lib/tarantool/response.ex:24: Tarantool.Response.parse_response/2
    (tarantool) lib/tarantool.ex:70: Tarantool.handle_info/2
    lib/connection.ex:812: Connection.handle_async/3
    (stdlib) gen_server.erl:601: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:667: :gen_server.handle_msg/5
    (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
Last message: {:tcp, #Port<0.5185>, <<206, 0, 0, 0, 80, 131, 0, 206, 0, 0, 0, 0, 1, 207, 0, 0, 0, 0, 0, 0, 0, 1, 5, 206, 0, 0, 1, 111, 129, 48, 221, 0, 0, 0, 1, 145, 129, 166, 112, 97, 114, 97, 109, 115, 129, 162, 105, 100, ...>>}
State: %{host: 'localhost', port: 3303, queue: %{1 => {#PID<0.156.0>, #Reference<0.0.8.216>}}, response_size: nil, salt: "JKXblH/KLxXCWXJ6jKLsmLlmnihN+FbNu7nqDXJZUq8=", sock: #Port<0.5185>, sync: 2, tail: "", timeout: 5000}
```

Suspect this is an issue with `:message_pack` library which looks outdated. Not really sure but may be replace it with https://github.com/lexmag/msgpax ? It looks more "alive" :)
